### PR TITLE
Improve workflow triggering

### DIFF
--- a/.github/workflows/dependabot-changesets.yml
+++ b/.github/workflows/dependabot-changesets.yml
@@ -3,6 +3,7 @@ name: Add changeset to Dependabot updates
 on:
   pull_request_target:
     types: [opened, synchronize, labeled]
+  workflow_dispatch:
 
 jobs:
   dependabot:
@@ -19,7 +20,7 @@ jobs:
       - name: Update PR
         uses: StafflinePeoplePlus/dependabot-changesets@v0.1.0
         with:
-          owner: MyGithubUser
-          repo: my-cool-repo
+          owner: @functorfactory
+          repo: eslint-config
           pr-number: ${{ github.event.pull_request.number }}
-          token: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,14 @@ name: Verify PR
 on:
   pull_request:
     types: [opened, synchronized, reopened]
+  paths:
+    - 'package.json'
+    - 'pnpm-lock.yaml'
+    - 'pnpm-workspace.yaml'
+    - 'tsup.config.ts'
+    - 'eslint.config.js'
+    - 'tsconfig.json'
+    - '**.ts'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsup.config.ts'
+      - 'src/**.ts'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
- Only call release and pr workflows on relevant path changes.

- Pass in real values to the dependabot-changeset workflow